### PR TITLE
feat(sdk): llmops foundation — issues #1, #2 + tier 1 primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,97 @@ run("user can't find report X")
 
 Trace appears at `$MLFLOW_TRACKING_URI` within seconds.
 
+## Observability primitives
+
+### Group traces by session and user
+
+```python
+with llmops.trace_agent("chat_turn"):
+    llmops.set_trace_metadata(session_id="conv-001", user_id="alice")
+    reply = your_llm(...)
+```
+
+Traces with the same `session_id` group under one row in the MLflow Sessions tab and are queryable via `mlflow.search_traces(filter_string='metadata."mlflow.trace.session" = \'conv-001\'')`.
+
+### Tag traces for filtering
+
+```python
+with llmops.trace_agent("agent_rilis"):
+    llmops.set_trace_tags(env="prod", team="prd-pipeline", retry_count=3)
+```
+
+Values are coerced to `str` at the SDK boundary. Filter via `tags."env" = 'prod'`.
+
+### Log hyperparameters at runtime
+
+```python
+with llmops.trace_agent("chatbot"):
+    llmops.log_hyperparams(model="qwen2.5:7b", temperature=0.7, top_k=40)
+    ollama.chat(...)
+```
+
+Values land on the active span as `llmops.hp.<key>` attributes — visible in the trace detail view.
+
+### Type your spans
+
+```python
+from llmops import SpanType
+
+@llmops.trace_agent("retriever_step", span_type=SpanType.RETRIEVER)
+def fetch_docs(q: str) -> list[str]: ...
+```
+
+Constants mirror MLflow 3.11.x's `SpanType` enum (15 values: `LLM`, `AGENT`, `CHAT_MODEL`, `RETRIEVER`, `TOOL`, `CHAIN`, `EMBEDDING`, `RERANKER`, `PARSER`, `MEMORY`, `WORKFLOW`, `TASK`, `GUARDRAIL`, `EVALUATOR`, `UNKNOWN`).
+
+### Capture outputs
+
+```python
+# As decorator — return value is auto-captured
+@llmops.trace_agent("agent_tujuan")
+def run(q: str) -> dict: return {"answer": ...}
+
+# As context manager — call set_outputs explicitly
+with llmops.trace_agent("agent_rilis") as t:
+    result = your_llm(...)
+    t.set_outputs(result)
+```
+
+### Version generation hyperparameters with the prompt
+
+```python
+llmops.register_prompt(
+    name="agent_demo",
+    template="answer the user: {{question}}",
+    model_config={"model": "qwen2.5:7b", "temperature": 0.7, "num_ctx": 4096},
+)
+```
+
+`model_config` lands on the prompt version itself, so changes to generation params bump the prompt version alongside the template.
+
+### Autolog third-party SDKs
+
+```python
+llmops.autolog("openai")        # mlflow.openai.autolog
+llmops.autolog("anthropic")     # mlflow.anthropic.autolog
+llmops.autolog("langchain", log_input_examples=True)
+```
+
+Passes through to `mlflow.<provider>.autolog(**kwargs)` for all 17 supported providers (`llmops.SUPPORTED_PROVIDERS`).
+
 ## API
 
 | Symbol | Purpose |
 |---|---|
-| `@llmops.trace_agent(name)` / `with llmops.trace_agent(name):` | wrap a function or block in a span |
+| `@llmops.trace_agent(name, span_type=None, **attrs)` / `with llmops.trace_agent(...) as t:` | wrap a function or block in a span; `t.set_outputs(value)` records the output |
+| `llmops.SpanType.{AGENT,LLM,RETRIEVER,...}` | canonical span-type string constants |
+| `llmops.set_trace_metadata(session_id=, user_id=)` | populate `TraceInfo.request_metadata` for Sessions tab grouping |
+| `llmops.set_trace_tags(**tags)` | populate `TraceInfo.tags` for `search_traces` filtering |
+| `llmops.log_hyperparams(**hp)` | record runtime hyperparams as `llmops.hp.*` span attributes |
 | `llmops.load_prompt("name@alias")` | load by alias (or `"name/version"`) — returns object with `.template` and `.format(**vars)` |
-| `llmops.register_prompt(name, template, ...)` | register a new version (idempotent) |
+| `llmops.register_prompt(name, template, model_config=None, ...)` | register a new version (idempotent); `model_config` versions generation hyperparams |
 | `llmops.set_alias(name, alias, version, from_alias=...)` | move alias; writes audit tags |
+| `llmops.autolog(provider, **kwargs)` | passthrough to `mlflow.<provider>.autolog(**kwargs)` |
+| `llmops.SUPPORTED_PROVIDERS` | frozenset of 17 supported autolog provider names |
 | `llmops.LLMOpsError` (and subclasses) | catch SDK-level errors |
 
 ## Environment
@@ -54,6 +137,43 @@ docker compose up -d --wait
 ```
 
 UI: <http://localhost:5001>.
+
+## Roadmap
+
+### Shipped — Tier 1 (current release)
+
+Foundation for production observability + prompt versioning. Resolves #1, #2, #3.
+
+- `trace_agent` context manager + decorator with adapter init guarantee
+- `SpanType` constants (15 values) for typed spans
+- `set_trace_metadata(session_id=, user_id=)` — populates `TraceInfo.request_metadata` for the MLflow Sessions tab and `search_traces` filtering
+- `set_trace_tags(**tags)` — populates `TraceInfo.tags` with str-coerced values
+- `log_hyperparams(**hp)` — runtime hyperparams as `llmops.hp.*` span attributes
+- `set_outputs(value)` / decorator auto-capture
+- `register_prompt(model_config=...)` — generation hyperparams versioned with the template
+- `autolog(provider, **kwargs)` — passthrough for 17 providers
+
+### Tier 2 — next (driver: agentic PRD pipeline)
+
+Priority-ordered. Each item is a thin wrapper over `mlflow.genai.*`; preserves the SDK's banned-module-rule architecture.
+
+| Priority | Feature | Why |
+|---|---|---|
+| 1 | `response_format` field in prompt YAML | PRD pipeline needs structured output enforcement (fixed sections: Tujuan / Rilis / Fitur / User Flow / Analytics). MLflow `register_prompt(response_format=...)` accepts Pydantic class or JSON schema. |
+| 2 | Chat-format prompts (`template:` accepts `list[dict]`) | PRD agents and most production chatbots use `[{role, content}, ...]` not single template strings. Already supported by MLflow natively. |
+| 3 | `llmops.evaluate(...)` thin wrapper | PRD regression testing using built-in scorers (Correctness, Guidelines, RetrievalRelevance) and custom judges via `make_judge`. |
+| 4 | `llmops.log_feedback(trace_id, value, rationale=)` | Human-review loop for the PRD generation pipeline. |
+
+Possible add-on (deferred unless performance demands it): parallel sub-agent context propagation via `mlflow.tracing.context` — only relevant if PRD sub-agents fan out via threads/asyncio (current span stack is `threading.local`).
+
+### Tier 3 — intentionally out-of-scope
+
+These MLflow features are useful but heavy and largely duplicate `mlflow.genai.*` directly. Recommendation: consumers use raw `mlflow` for these rather than expanding the SDK surface.
+
+- Datasets API (`mlflow.genai.datasets`)
+- `optimize_prompt` (DSPy-based prompt optimization)
+- `ConversationSimulator`
+- Labeling sessions
 
 ---
 

--- a/prompts/_schema.py
+++ b/prompts/_schema.py
@@ -1,9 +1,14 @@
-"""Pydantic v2 model for prompt YAML files. Validation rules per spec Appendix B."""
+"""Pydantic v2 model for prompt YAML files. Validation rules per spec Appendix B.
+
+This module mirrors src/llmops/_prompt_schema.py — the duplicate exists so
+scripts/validate_prompts.py (called by CI) can import the schema without
+needing the SDK installed. Keep them in lockstep.
+"""
 
 from __future__ import annotations
 
 import re
-from typing import Self
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -12,14 +17,19 @@ _VAR_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
 
 
 class PromptYAML(BaseModel):
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
 
-    schema_version: int = Field(..., ge=1, le=1)
+    schema_version: int = Field(..., ge=1, le=2)
     name: str
     description: str = Field(..., min_length=10)
     template: str
     variables: list[str]
     tags: dict[str, str] = Field(default_factory=dict)
+    mlflow_model_config: dict[str, Any] | None = Field(default=None, alias="model_config")
 
     @model_validator(mode="after")
     def _validate(self) -> Self:
@@ -45,4 +55,10 @@ class PromptYAML(BaseModel):
         for k, v in self.tags.items():
             if not isinstance(k, str) or not isinstance(v, str):
                 raise ValueError("tags must be flat dict[str, str]")
+
+        if self.mlflow_model_config is not None and self.schema_version < 2:
+            raise ValueError(
+                "`model_config` requires schema_version >= 2 "
+                "(bump `schema_version: 2` to use it)"
+            )
         return self

--- a/src/llmops/__init__.py
+++ b/src/llmops/__init__.py
@@ -19,7 +19,7 @@ Configuration via environment variables only (read on first call):
 
 from __future__ import annotations
 
-from llmops._autolog import autolog
+from llmops._autolog import SUPPORTED_PROVIDERS, autolog
 from llmops.exceptions import (
     LLMOpsConfigError,
     LLMOpsError,
@@ -40,6 +40,7 @@ __all__ = [
     "LLMOpsError",
     "LLMOpsPromptNotFoundError",
     "LLMOpsValidationError",
+    "SUPPORTED_PROVIDERS",
     "SpanType",
     "autolog",
     "load_prompt",

--- a/src/llmops/__init__.py
+++ b/src/llmops/__init__.py
@@ -1,10 +1,15 @@
 """bni-llmops — LLM Ops SDK for BNI.
 
 Public API:
-    llmops.trace_agent(name, **attrs)         # context manager + decorator
-    llmops.load_prompt(ref)                   # 'name@alias' or 'name/version'
+    llmops.trace_agent(name, span_type=None, **attrs)  # context manager + decorator
+    llmops.SpanType                                    # canonical span type constants
+    llmops.load_prompt(ref)                            # 'name@alias' or 'name/version'
     llmops.register_prompt(name, template, ...)
     llmops.set_alias(name, alias, version, from_alias=None)
+    llmops.log_hyperparams(**hp)                       # span-level hyperparams
+    llmops.set_trace_tags(**tags)                      # arbitrary trace tags
+    llmops.set_trace_metadata(session_id=, user_id=)   # canonical session/user IDs
+    llmops.autolog(provider, **kwargs)                 # mlflow.<provider>.autolog passthrough
 
 Configuration via environment variables only (read on first call):
     MLFLOW_TRACKING_URI       (required)
@@ -14,6 +19,7 @@ Configuration via environment variables only (read on first call):
 
 from __future__ import annotations
 
+from llmops._autolog import autolog
 from llmops.exceptions import (
     LLMOpsConfigError,
     LLMOpsError,
@@ -21,15 +27,26 @@ from llmops.exceptions import (
     LLMOpsValidationError,
 )
 from llmops.prompts import load_prompt, register_prompt, set_alias
-from llmops.tracing import trace_agent
+from llmops.tracing import (
+    SpanType,
+    log_hyperparams,
+    set_trace_metadata,
+    set_trace_tags,
+    trace_agent,
+)
 
 __all__ = [
     "LLMOpsConfigError",
     "LLMOpsError",
     "LLMOpsPromptNotFoundError",
     "LLMOpsValidationError",
+    "SpanType",
+    "autolog",
     "load_prompt",
+    "log_hyperparams",
     "register_prompt",
     "set_alias",
+    "set_trace_metadata",
+    "set_trace_tags",
     "trace_agent",
 ]

--- a/src/llmops/_autolog.py
+++ b/src/llmops/_autolog.py
@@ -1,0 +1,71 @@
+"""Autolog passthrough — one-line auto-instrumentation for LLM/agent frameworks.
+
+Wraps ``mlflow.{provider}.autolog()`` so consumers don't import mlflow directly,
+and ensures the SDK's tracking URI and experiment are set first (Issue #1
+applies to autolog too — without ``MLflowAdapter.initialise()`` the auto-captured
+traces would land in 'Default').
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any
+
+from llmops._config import get_config
+from llmops.tracing import _get_adapter
+
+_log = logging.getLogger(__name__)
+
+# MLflow 3.11.1 integration submodules with autolog support (verified against
+# https://github.com/mlflow/mlflow/tree/v3.11.1/mlflow). When MLflow ships a new
+# integration, add it here; SDK consumers don't have to upgrade mid-cycle.
+SUPPORTED_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "ag2",
+        "anthropic",
+        "autogen",
+        "bedrock",
+        "crewai",
+        "dspy",
+        "gemini",
+        "groq",
+        "haystack",
+        "langchain",
+        "litellm",
+        "llama_index",
+        "mistral",
+        "openai",
+        "pydantic_ai",
+        "semantic_kernel",
+        "smolagents",
+    }
+)
+
+
+def autolog(provider: str, **kwargs: Any) -> None:
+    """Enable automatic tracing for an LLM/agent framework.
+
+    Example::
+
+        llmops.autolog("openai")
+        llmops.autolog("langchain", log_inputs_outputs=False)
+
+    Passes ``**kwargs`` straight to ``mlflow.{provider}.autolog()`` — see each
+    integration's MLflow doc for supported flags (``disable``, ``silent``,
+    ``log_input_examples``, framework-specific toggles, etc.).
+
+    Disabled when ``LLMOPS_DISABLE_TRACING=true``. Raises ``ValueError`` if
+    ``provider`` is not in :data:`SUPPORTED_PROVIDERS`.
+    """
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(
+            f"unsupported autolog provider {provider!r}; "
+            f"supported: {sorted(SUPPORTED_PROVIDERS)}"
+        )
+    if get_config().disable_tracing:
+        return
+
+    _get_adapter()
+    mod = importlib.import_module(f"mlflow.{provider}")  # noqa: TID253
+    mod.autolog(**kwargs)

--- a/src/llmops/_mlflow_adapter.py
+++ b/src/llmops/_mlflow_adapter.py
@@ -72,8 +72,10 @@ class MLflowAdapter:
         return mlflow.genai.load_prompt(name_or_uri=uri)
 
     def set_alias(self, name: str, alias: str, version: int) -> None:
-        # NOTE: this lives on mlflow.* (root namespace), NOT mlflow.genai.*
-        mlflow.set_prompt_alias(name, alias, version)
+        # MLflow 3.x moved prompt-registry APIs into the genai namespace.
+        # The root-level ``mlflow.set_prompt_alias`` still works in 3.11.x but
+        # emits a FutureWarning on every call — use ``mlflow.genai`` directly.
+        mlflow.genai.set_prompt_alias(name, alias, version)
 
     def write_prompt_version_tags(self, name: str, version: int, tags: dict[str, str]) -> None:
         """Write each (key, value) in `tags` as a tag on the given prompt version

--- a/src/llmops/_mlflow_adapter.py
+++ b/src/llmops/_mlflow_adapter.py
@@ -18,6 +18,9 @@ class _PromptObj(Protocol):
     name: str
     version: int
     template: str
+    # NOTE: PromptVersion also exposes ``.model_config`` (MLflow 3.8+) when the
+    # prompt was registered with one. We don't declare it on the Protocol because
+    # not every consumer / mock path supplies it; callers use getattr fallback.
 
     def format(self, **vars: Any) -> str: ...  # noqa: A002
 
@@ -45,12 +48,16 @@ class MLflowAdapter:
         template: str,
         commit_message: str | None = None,
         tags: dict[str, str] | None = None,
+        model_config: dict[str, Any] | None = None,
     ) -> _PromptObj:
+        # ``model_config`` is the canonical MLflow 3.8+ field for versioning
+        # generation hyperparameters alongside the prompt template (Issue #2).
         return mlflow.genai.register_prompt(
             name=name,
             template=template,
             commit_message=commit_message,
             tags=tags,
+            model_config=model_config,
         )
 
     def load_prompt(

--- a/src/llmops/_prompt_schema.py
+++ b/src/llmops/_prompt_schema.py
@@ -1,9 +1,21 @@
-"""Pydantic v2 model for prompt YAML files. Validation rules per spec Appendix B."""
+"""Pydantic v2 model for prompt YAML files. Validation rules per spec Appendix B.
+
+Schema versions:
+    1: original — name, description, template, variables, tags
+    2: + model_config (Issue #2) — optional dict[str, Any] of generation
+       hyperparameters (temperature, top_k, num_ctx, model_name, etc.). Maps
+       1:1 to ``mlflow.genai.register_prompt(model_config=...)`` (native MLflow
+       3.8+ field, exposed back as ``prompt.model_config`` after load_prompt).
+
+The ``mlflow_model_config`` field name is internal-only — its YAML alias is
+``model_config``. The rename is forced by Pydantic v2's reservation of the
+``model_config`` class attribute for ConfigDict.
+"""
 
 from __future__ import annotations
 
 import re
-from typing import Self
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -12,14 +24,19 @@ _VAR_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
 
 
 class PromptYAML(BaseModel):
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
 
-    schema_version: int = Field(..., ge=1, le=1)
+    schema_version: int = Field(..., ge=1, le=2)
     name: str
     description: str = Field(..., min_length=10)
     template: str
     variables: list[str]
     tags: dict[str, str] = Field(default_factory=dict)
+    mlflow_model_config: dict[str, Any] | None = Field(default=None, alias="model_config")
 
     @model_validator(mode="after")
     def _validate(self) -> Self:
@@ -45,4 +62,10 @@ class PromptYAML(BaseModel):
         for k, v in self.tags.items():
             if not isinstance(k, str) or not isinstance(v, str):
                 raise ValueError("tags must be flat dict[str, str]")
+
+        if self.mlflow_model_config is not None and self.schema_version < 2:
+            raise ValueError(
+                "`model_config` requires schema_version >= 2 "
+                "(bump `schema_version: 2` to use it)"
+            )
         return self

--- a/src/llmops/cli.py
+++ b/src/llmops/cli.py
@@ -106,6 +106,7 @@ def register_prompts(
                 template=schema.template,
                 commit_message=os.environ.get("GITHUB_SHA", ""),
                 tags=schema.tags,
+                model_config=schema.mlflow_model_config,
             )
             if set_staging:
                 _set_alias(schema.name, alias="staging", version=result.version)

--- a/src/llmops/prompts.py
+++ b/src/llmops/prompts.py
@@ -83,27 +83,40 @@ def register_prompt(
     template: str,
     commit_message: str | None = None,
     tags: dict[str, str] | None = None,
+    model_config: dict[str, Any] | None = None,
 ) -> Any:
     """Register a new prompt version. Idempotent (v1 strategy): if any of the
-    `staging` or `production` aliases points at a version whose template equals
-    the new template, return that version without creating a new one.
+    `staging` or `production` aliases points at a version whose template AND
+    model_config equal the new ones, return that version without creating a
+    new one.
+
+    Issue #2: model_config (generation hyperparameters dict) participates in
+    the idempotence check, so changing temperature/top_k/etc. produces a new
+    version (rollback-able via set_alias).
 
     Note: a more thorough check (search ALL versions) is v2 work — the search API
     surface needs validation against MLflow 3.11.x first.
     """
     adapter = _get_adapter()
 
-    existing = None
     for try_alias in ("staging", "production"):
         try:
             existing = adapter.load_prompt(name=name, alias=try_alias)
-            if existing.template == template:
-                return existing
         except Exception:  # noqa: BLE001
             continue
+        if existing.template != template:
+            continue
+        existing_mc = getattr(existing, "model_config", None) or None
+        wanted_mc = model_config or None
+        if existing_mc == wanted_mc:
+            return existing
 
     return adapter.register_prompt(
-        name=name, template=template, commit_message=commit_message, tags=tags
+        name=name,
+        template=template,
+        commit_message=commit_message,
+        tags=tags,
+        model_config=model_config,
     )
 
 

--- a/src/llmops/tracing.py
+++ b/src/llmops/tracing.py
@@ -67,23 +67,31 @@ def _current_span() -> Any | None:
 def set_trace_tags(**tags: Any) -> None:
     """Attach mutable user-defined tags to the active trace.
 
-    Writes to ``TraceInfo.tags`` via ``mlflow.update_current_trace(tags=...)``
+    Writes to ``TraceInfo.tags`` via ``MlflowClient.set_trace_tag(trace_id, ...)``
     so the values land in the MLflow trace overview and are queryable via
     ``mlflow.search_traces(filter_string='tags."env" = \\'dev\\'')`` (quote
     keys that contain dots).
 
-    Values are coerced to ``str`` to satisfy MLflow's ``dict[str, str]`` tag
-    contract. Outside an active trace, MLflow logs a warning and the call is
-    a no-op (never raises). Disabled when ``LLMOPS_DISABLE_TRACING=true``.
+    Must be called inside an active ``trace_agent`` context. Outside one, the
+    call is a warning + no-op (never raises). Disabled when
+    ``LLMOPS_DISABLE_TRACING=true``. Values are coerced to ``str`` to satisfy
+    MLflow's ``dict[str, str]`` tag contract.
     """
     if not tags or get_config().disable_tracing:
         return
+    stack = _stack()
+    if not stack:
+        _log.warning("llmops.set_trace_tags called outside trace_agent — ignored")
+        return
+    trace_id = stack[0].trace_id
     try:
-        import mlflow  # noqa: TID253, PLC0415
+        from mlflow import MlflowClient  # noqa: TID253, PLC0415
 
-        mlflow.update_current_trace(tags={k: str(v) for k, v in tags.items()})
+        client = MlflowClient()
+        for k, v in tags.items():
+            client.set_trace_tag(trace_id, k, str(v))
     except Exception as e:  # noqa: BLE001
-        _log.warning("llmops.set_trace_tags update_current_trace failed: %r", e)
+        _log.warning("llmops.set_trace_tags set_trace_tag failed: %r", e)
 
 
 def set_trace_metadata(
@@ -92,13 +100,16 @@ def set_trace_metadata(
     """Attach canonical session/user identifiers to the active trace.
 
     Writes to ``TraceInfo.request_metadata`` under MLflow's reserved keys
-    ``mlflow.trace.session`` and ``mlflow.trace.user`` via
-    ``mlflow.update_current_trace(metadata=...)``. The MLflow UI's Sessions
-    tab and ``mlflow.search_traces(filter_string='metadata."mlflow.trace.session"
+    ``mlflow.trace.session`` and ``mlflow.trace.user`` via the in-memory trace
+    manager (the same path ``mlflow.update_current_trace`` uses internally —
+    we bypass the fluent active-span check because ``trace_agent`` builds
+    traces with the low-level ``MlflowClient.start_trace`` API, which does
+    not register a fluent active span). The MLflow UI's Sessions tab and
+    ``mlflow.search_traces(filter_string='metadata."mlflow.trace.session"
     = ...')`` consume these keys for grouping and filtering.
 
-    Note: trace metadata is **immutable once the trace is logged** — set
-    session/user IDs once at trace start, don't try to mutate mid-trace.
+    Must be called inside an active ``trace_agent`` context, before the root
+    trace ends — metadata is **immutable once the trace is logged**.
     """
     meta: dict[str, str] = {}
     if session_id is not None:
@@ -107,12 +118,19 @@ def set_trace_metadata(
         meta["mlflow.trace.user"] = user_id
     if not meta or get_config().disable_tracing:
         return
+    stack = _stack()
+    if not stack:
+        _log.warning("llmops.set_trace_metadata called outside trace_agent — ignored")
+        return
+    trace_id = stack[0].trace_id
     try:
-        import mlflow  # noqa: TID253, PLC0415
+        from mlflow.tracing.trace_manager import InMemoryTraceManager  # noqa: TID253, PLC0415
 
-        mlflow.update_current_trace(metadata=meta)
+        mgr = InMemoryTraceManager.get_instance()
+        for k, v in meta.items():
+            mgr.set_trace_metadata(trace_id, k, str(v))
     except Exception as e:  # noqa: BLE001
-        _log.warning("llmops.set_trace_metadata update_current_trace failed: %r", e)
+        _log.warning("llmops.set_trace_metadata failed: %r", e)
 
 
 def log_hyperparams(**hyperparams: Any) -> None:

--- a/src/llmops/tracing.py
+++ b/src/llmops/tracing.py
@@ -65,25 +65,25 @@ def _current_span() -> Any | None:
 
 
 def set_trace_tags(**tags: Any) -> None:
-    """Attach user-defined tags to the active trace.
+    """Attach mutable user-defined tags to the active trace.
 
-    Tags are written as attributes on the trace's root span, which makes them
-    appear in the MLflow trace overview and filterable via
-    ``mlflow.search_traces(filter_string="attributes.foo='bar'")``.
+    Writes to ``TraceInfo.tags`` via ``mlflow.update_current_trace(tags=...)``
+    so the values land in the MLflow trace overview and are queryable via
+    ``mlflow.search_traces(filter_string='tags."env" = \\'dev\\'')`` (quote
+    keys that contain dots).
 
-    Outside a ``trace_agent`` context, this is a warning + no-op (never raises).
-    Disabled when ``LLMOPS_DISABLE_TRACING=true``.
+    Values are coerced to ``str`` to satisfy MLflow's ``dict[str, str]`` tag
+    contract. Outside an active trace, MLflow logs a warning and the call is
+    a no-op (never raises). Disabled when ``LLMOPS_DISABLE_TRACING=true``.
     """
-    if get_config().disable_tracing or not tags:
-        return
-    stack = _stack()
-    if not stack:
-        _log.warning("llmops.set_trace_tags called outside trace_agent — ignored")
+    if not tags or get_config().disable_tracing:
         return
     try:
-        stack[0].set_attributes(dict(tags))
+        import mlflow  # noqa: TID253, PLC0415
+
+        mlflow.update_current_trace(tags={k: str(v) for k, v in tags.items()})
     except Exception as e:  # noqa: BLE001
-        _log.warning("llmops.set_trace_tags set_attributes failed: %r", e)
+        _log.warning("llmops.set_trace_tags update_current_trace failed: %r", e)
 
 
 def set_trace_metadata(
@@ -91,18 +91,28 @@ def set_trace_metadata(
 ) -> None:
     """Attach canonical session/user identifiers to the active trace.
 
-    Maps to MLflow's reserved metadata keys ``mlflow.trace.session`` and
-    ``mlflow.trace.user``, which the MLflow UI uses for grouping and filtering
-    in the Sessions tab. Written as root-span attributes (the entry point that
-    works with the low-level MlflowClient API used by ``trace_agent``).
+    Writes to ``TraceInfo.request_metadata`` under MLflow's reserved keys
+    ``mlflow.trace.session`` and ``mlflow.trace.user`` via
+    ``mlflow.update_current_trace(metadata=...)``. The MLflow UI's Sessions
+    tab and ``mlflow.search_traces(filter_string='metadata."mlflow.trace.session"
+    = ...')`` consume these keys for grouping and filtering.
+
+    Note: trace metadata is **immutable once the trace is logged** — set
+    session/user IDs once at trace start, don't try to mutate mid-trace.
     """
-    meta: dict[str, Any] = {}
+    meta: dict[str, str] = {}
     if session_id is not None:
         meta["mlflow.trace.session"] = session_id
     if user_id is not None:
         meta["mlflow.trace.user"] = user_id
-    if meta:
-        set_trace_tags(**meta)
+    if not meta or get_config().disable_tracing:
+        return
+    try:
+        import mlflow  # noqa: TID253, PLC0415
+
+        mlflow.update_current_trace(metadata=meta)
+    except Exception as e:  # noqa: BLE001
+        _log.warning("llmops.set_trace_metadata update_current_trace failed: %r", e)
 
 
 def log_hyperparams(**hyperparams: Any) -> None:

--- a/src/llmops/tracing.py
+++ b/src/llmops/tracing.py
@@ -15,6 +15,32 @@ _log = logging.getLogger(__name__)
 _adapter: MLflowAdapter | None = None
 _local = threading.local()
 
+# Sentinel for "outputs not set" — distinct from a user explicitly passing None.
+_UNSET = object()
+
+
+class SpanType:
+    """Canonical MLflow span type string constants (mirrors
+    ``mlflow.entities.SpanType`` as of MLflow 3.11.x — 15 values). Use with
+    ``trace_agent(span_type=SpanType.AGENT)`` for IDE-friendly autocomplete and
+    typo safety. Users may also pass raw strings; MLflow accepts any value."""
+
+    LLM = "LLM"
+    CHAIN = "CHAIN"
+    AGENT = "AGENT"
+    TOOL = "TOOL"
+    CHAT_MODEL = "CHAT_MODEL"
+    RETRIEVER = "RETRIEVER"
+    PARSER = "PARSER"
+    EMBEDDING = "EMBEDDING"
+    RERANKER = "RERANKER"
+    MEMORY = "MEMORY"
+    UNKNOWN = "UNKNOWN"
+    WORKFLOW = "WORKFLOW"
+    TASK = "TASK"
+    GUARDRAIL = "GUARDRAIL"
+    EVALUATOR = "EVALUATOR"
+
 
 def _get_adapter() -> MLflowAdapter:
     global _adapter
@@ -30,6 +56,87 @@ def _stack() -> list[Any]:
     return _local.spans
 
 
+def _current_span() -> Any | None:
+    """Return the topmost live span on the thread-local stack, or None if no
+    trace_agent is active. Span objects expose ``.trace_id`` and ``.span_id``
+    directly, so callers don't need a wrapping dict."""
+    stack = _stack()
+    return stack[-1] if stack else None
+
+
+def set_trace_tags(**tags: Any) -> None:
+    """Attach user-defined tags to the active trace.
+
+    Tags are written as attributes on the trace's root span, which makes them
+    appear in the MLflow trace overview and filterable via
+    ``mlflow.search_traces(filter_string="attributes.foo='bar'")``.
+
+    Outside a ``trace_agent`` context, this is a warning + no-op (never raises).
+    Disabled when ``LLMOPS_DISABLE_TRACING=true``.
+    """
+    if get_config().disable_tracing or not tags:
+        return
+    stack = _stack()
+    if not stack:
+        _log.warning("llmops.set_trace_tags called outside trace_agent — ignored")
+        return
+    try:
+        stack[0].set_attributes(dict(tags))
+    except Exception as e:  # noqa: BLE001
+        _log.warning("llmops.set_trace_tags set_attributes failed: %r", e)
+
+
+def set_trace_metadata(
+    session_id: str | None = None, user_id: str | None = None
+) -> None:
+    """Attach canonical session/user identifiers to the active trace.
+
+    Maps to MLflow's reserved metadata keys ``mlflow.trace.session`` and
+    ``mlflow.trace.user``, which the MLflow UI uses for grouping and filtering
+    in the Sessions tab. Written as root-span attributes (the entry point that
+    works with the low-level MlflowClient API used by ``trace_agent``).
+    """
+    meta: dict[str, Any] = {}
+    if session_id is not None:
+        meta["mlflow.trace.session"] = session_id
+    if user_id is not None:
+        meta["mlflow.trace.user"] = user_id
+    if meta:
+        set_trace_tags(**meta)
+
+
+def log_hyperparams(**hyperparams: Any) -> None:
+    """Record runtime hyperparameters as attributes on the currently-active span.
+
+    Issue #2 (Option 2): a runtime escape hatch for consumers that want to log
+    generation hyperparameters (temperature, top_k, num_ctx, model name, etc.)
+    without going through the prompt registry. Values are written as span
+    attributes under the ``llmops.hp.*`` namespace.
+
+    Must be called inside an active ``trace_agent`` context. Outside one, the
+    call is a warning + no-op (never raises). Disabled when
+    ``LLMOPS_DISABLE_TRACING=true``.
+
+    Example::
+
+        with llmops.trace_agent("chatbot"):
+            llmops.log_hyperparams(model="qwen2.5:7b", temperature=0.7, top_k=40)
+            ollama.chat(...)
+    """
+    if get_config().disable_tracing:
+        return
+
+    span = _current_span()
+    if span is None:
+        _log.warning("llmops.log_hyperparams called outside trace_agent — ignored")
+        return
+
+    try:
+        span.set_attributes({f"llmops.hp.{k}": v for k, v in hyperparams.items()})
+    except Exception as e:  # noqa: BLE001
+        _log.warning("llmops.log_hyperparams set_attributes failed: %r", e)
+
+
 class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API surface)
     """Context manager + decorator — single object exposes both interfaces.
 
@@ -38,22 +145,37 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
         with trace_agent("agent_tujuan"):
             ...
 
-        @trace_agent("agent_rilis")
+        @trace_agent("agent_rilis", span_type=SpanType.AGENT)
         def run_agent_rilis(...): ...
+
+    The ``span_type`` parameter accepts any MLflow ``SpanType`` value (``LLM``,
+    ``CHAT_MODEL``, ``RETRIEVER``, ``TOOL``, ``AGENT``, ``CHAIN``, ``EMBEDDING``,
+    ``RERANKER``, ``PARSER``, ``MEMORY``, ``WORKFLOW``, ``TASK``, ``GUARDRAIL``,
+    ``EVALUATOR``, ``UNKNOWN``). Use the re-exported ``llmops.SpanType`` enum
+    rather than raw strings so renames stay safe.
     """
 
-    def __init__(self, name: str, **attrs: Any) -> None:
+    def __init__(self, name: str, span_type: str | None = None, **attrs: Any) -> None:
         self.name = name
+        self.span_type = span_type
         self.attrs = attrs
         self._span = None
         self._client = None
         self._trace_handle = None
         self._is_root = False
+        self._outputs: Any = _UNSET
 
     def __enter__(self) -> trace_agent:
         cfg = get_config()
         if cfg.disable_tracing:
             return self
+
+        # Issue #1: ensure MLflowAdapter.initialise() ran (set_tracking_uri +
+        # set_experiment) before any MlflowClient call. Without this, traces
+        # land in 'Default' for consumers that use trace_agent without first
+        # touching the prompt registry. The adapter's _initialised flag makes
+        # this a no-op after the first call.
+        _get_adapter()
 
         try:
             from mlflow import MlflowClient  # noqa: TID253
@@ -64,18 +186,22 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
                 handle = self._client.start_trace(name=self.name, inputs=self.attrs or None)
                 self._trace_handle = handle
                 self._is_root = True
-                stack.append({"trace_id": handle.trace_id, "span_id": handle.span_id})
+                stack.append(handle)
+                if self.span_type:
+                    handle.set_span_type(self.span_type)
             else:
                 parent = stack[-1]
                 span = self._client.start_span(
                     name=self.name,
-                    trace_id=parent["trace_id"],
-                    parent_id=parent["span_id"],
+                    trace_id=parent.trace_id,
+                    parent_id=parent.span_id,
                     inputs=self.attrs or None,
                 )
                 self._span = span
                 self._is_root = False
-                stack.append({"trace_id": parent["trace_id"], "span_id": span.span_id})
+                stack.append(span)
+                if self.span_type:
+                    span.set_span_type(self.span_type)
         except Exception as e:  # noqa: BLE001
             _log.warning("llmops trace_agent('%s') start failed: %r", self.name, e)
         return self
@@ -89,19 +215,43 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
             if stack:
                 stack.pop()
             status = "ERROR" if exc_type else "OK"
+            end_kwargs: dict[str, Any] = {"status": status}
+            if self._outputs is not _UNSET:
+                end_kwargs["outputs"] = self._outputs
             if self._is_root and self._trace_handle is not None:
                 # Flush accumulated prompt_versions BEFORE ending the trace,
                 # so the tag attaches to the still-active run.
                 self._flush_prompt_versions()
-                self._client.end_trace(trace_id=self._trace_handle.trace_id, status=status)
+                self._client.end_trace(trace_id=self._trace_handle.trace_id, **end_kwargs)
             elif self._span is not None:
                 self._client.end_span(
                     trace_id=self._span.trace_id,
                     span_id=self._span.span_id,
-                    status=status,
+                    **end_kwargs,
                 )
         except Exception as e:  # noqa: BLE001
             _log.warning("llmops trace_agent('%s') end failed: %r", self.name, e)
+
+    def set_outputs(self, value: Any) -> None:
+        """Record the trace/span output. Captured automatically when ``trace_agent``
+        is used as a decorator (the wrapped function's return value). Call
+        explicitly inside a ``with trace_agent(...) as t:`` block to record
+        outputs in context-manager form."""
+        self._outputs = value
+
+    def __call__(self, func: Any) -> Any:
+        """Decorator form — auto-captures the wrapped function's return value as
+        the span's outputs, then re-raises any exception unchanged."""
+        from functools import wraps
+
+        @wraps(func)
+        def inner(*args: Any, **kwargs: Any) -> Any:
+            with self._recreate_cm() as cm:
+                result = func(*args, **kwargs)
+                cm.set_outputs(result)
+                return result
+
+        return inner
 
     def _flush_prompt_versions(self) -> None:
         """Serialize the thread-local prompt_versions dict and write it as a run tag.

--- a/tests/unit/test_autolog.py
+++ b/tests/unit/test_autolog.py
@@ -1,0 +1,129 @@
+"""autolog passthrough — verify provider validation, adapter init, and
+delegation to mlflow.<provider>.autolog()."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_mlflow_for_autolog(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Inject a mock mlflow with provider submodules that expose autolog()."""
+    mod = types.ModuleType("mlflow")
+    mod.set_tracking_uri = MagicMock()  # type: ignore[attr-defined]
+    mod.set_experiment = MagicMock()  # type: ignore[attr-defined]
+    mod.set_tag = MagicMock()  # type: ignore[attr-defined]
+    mod.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
+    mod.MlflowClient = MagicMock()  # type: ignore[attr-defined]
+    genai = types.ModuleType("mlflow.genai")
+    genai.register_prompt = MagicMock()  # type: ignore[attr-defined]
+    genai.load_prompt = MagicMock()  # type: ignore[attr-defined]
+    mod.genai = genai  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "mlflow", mod)
+    monkeypatch.setitem(sys.modules, "mlflow.genai", genai)
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://x:5001")
+
+    provider_mocks: dict[str, MagicMock] = {}
+    for provider in ("openai", "anthropic", "langchain", "llama_index", "ag2"):
+        sub = types.ModuleType(f"mlflow.{provider}")
+        autolog_mock = MagicMock()
+        sub.autolog = autolog_mock  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, f"mlflow.{provider}", sub)
+        provider_mocks[provider] = autolog_mock
+
+    for name in ("llmops._config", "llmops._mlflow_adapter", "llmops.tracing", "llmops._autolog"):
+        sys.modules.pop(name, None)
+
+    return {"mlflow": mod, "providers": provider_mocks}
+
+
+def test_autolog_calls_provider_autolog(
+    fake_mlflow_for_autolog: dict[str, MagicMock],
+) -> None:
+    from llmops._autolog import autolog
+
+    autolog("openai")
+
+    fake_mlflow_for_autolog["providers"]["openai"].assert_called_once_with()
+
+
+def test_autolog_forwards_kwargs(
+    fake_mlflow_for_autolog: dict[str, MagicMock],
+) -> None:
+    from llmops._autolog import autolog
+
+    autolog("langchain", log_inputs_outputs=False, silent=True)
+
+    fake_mlflow_for_autolog["providers"]["langchain"].assert_called_once_with(
+        log_inputs_outputs=False, silent=True
+    )
+
+
+def test_autolog_initialises_adapter_first(
+    fake_mlflow_for_autolog: dict[str, MagicMock],
+) -> None:
+    """Issue #1 corollary: autolog'd traces must also land in the configured
+    experiment, so set_tracking_uri + set_experiment must run before the
+    provider's autolog hook fires."""
+    from llmops._autolog import autolog
+
+    autolog("anthropic")
+
+    mlflow_mod = fake_mlflow_for_autolog["mlflow"]
+    mlflow_mod.set_tracking_uri.assert_called_once_with("http://x:5001")
+    mlflow_mod.set_experiment.assert_called_once_with("bni-agentic-prd")
+
+
+def test_autolog_unsupported_provider_raises(
+    fake_mlflow_for_autolog: dict[str, MagicMock],
+) -> None:
+    from llmops._autolog import autolog
+
+    with pytest.raises(ValueError, match="unsupported autolog provider"):
+        autolog("nonexistent_framework")
+
+
+def test_autolog_disabled_is_noop(
+    fake_mlflow_for_autolog: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLMOPS_DISABLE_TRACING", "true")
+    sys.modules.pop("llmops._config", None)
+    sys.modules.pop("llmops._autolog", None)
+
+    from llmops._autolog import autolog
+
+    autolog("openai")  # no-op
+    fake_mlflow_for_autolog["providers"]["openai"].assert_not_called()
+
+
+def test_supported_providers_covers_known_integrations() -> None:
+    """Pin the supported-provider list so a regression catches accidental
+    deletions. MLflow 3.11.1 ships these 17 integration submodules."""
+    from llmops._autolog import SUPPORTED_PROVIDERS
+
+    expected = {
+        "ag2",
+        "anthropic",
+        "autogen",
+        "bedrock",
+        "crewai",
+        "dspy",
+        "gemini",
+        "groq",
+        "haystack",
+        "langchain",
+        "litellm",
+        "llama_index",
+        "mistral",
+        "openai",
+        "pydantic_ai",
+        "semantic_kernel",
+        "smolagents",
+    }
+    assert frozenset(expected) == SUPPORTED_PROVIDERS

--- a/tests/unit/test_mlflow_adapter.py
+++ b/tests/unit/test_mlflow_adapter.py
@@ -19,7 +19,6 @@ def fake_mlflow(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     mod.set_tracking_uri = MagicMock()  # type: ignore[attr-defined]
     mod.set_experiment = MagicMock()  # type: ignore[attr-defined]
     mod.set_tag = MagicMock()  # type: ignore[attr-defined]
-    mod.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
 
     genai = types.ModuleType("mlflow.genai")
     genai.register_prompt = MagicMock(  # type: ignore[attr-defined]
@@ -28,6 +27,7 @@ def fake_mlflow(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     genai.load_prompt = MagicMock(  # type: ignore[attr-defined]
         return_value=types.SimpleNamespace(name="x", version=1, template="t")
     )
+    genai.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
     mod.genai = genai  # type: ignore[attr-defined]
 
     monkeypatch.setitem(sys.modules, "mlflow", mod)
@@ -96,12 +96,13 @@ def test_adapter_register_prompt_with_model_config(fake_mlflow: MagicMock) -> No
     )
 
 
-def test_adapter_set_alias_calls_root_namespace(fake_mlflow: MagicMock) -> None:
-    """set_prompt_alias is on mlflow.* not mlflow.genai.* — adapter must use the right one."""
+def test_adapter_set_alias_calls_genai_namespace(fake_mlflow: MagicMock) -> None:
+    """In MLflow 3.x prompt-registry APIs live under mlflow.genai.* — using
+    the root mlflow.set_prompt_alias still works but emits a FutureWarning."""
     from llmops._mlflow_adapter import MLflowAdapter
 
     cfg = Config(tracking_uri="http://x", experiment_name="e", disable_tracing=False)
     a = MLflowAdapter(cfg)
     a.set_alias("agent_tujuan", alias="staging", version=3)
 
-    fake_mlflow.set_prompt_alias.assert_called_once_with("agent_tujuan", "staging", 3)
+    fake_mlflow.genai.set_prompt_alias.assert_called_once_with("agent_tujuan", "staging", 3)

--- a/tests/unit/test_mlflow_adapter.py
+++ b/tests/unit/test_mlflow_adapter.py
@@ -56,7 +56,7 @@ def test_adapter_register_prompt_calls_genai(fake_mlflow: MagicMock) -> None:
     a.register_prompt(name="p", template="t", commit_message="c", tags={"k": "v"})
 
     fake_mlflow.genai.register_prompt.assert_called_once_with(
-        name="p", template="t", commit_message="c", tags={"k": "v"}
+        name="p", template="t", commit_message="c", tags={"k": "v"}, model_config=None
     )
 
 
@@ -69,6 +69,30 @@ def test_adapter_load_prompt_uri_form(fake_mlflow: MagicMock) -> None:
 
     fake_mlflow.genai.load_prompt.assert_called_once_with(
         name_or_uri="prompts:/agent_tujuan@production"
+    )
+
+
+def test_adapter_register_prompt_with_model_config(fake_mlflow: MagicMock) -> None:
+    """Issue #2: adapter forwards model_config kwarg to mlflow.genai.register_prompt
+    so generation hyperparameters are versioned with the prompt template."""
+    from llmops._mlflow_adapter import MLflowAdapter
+
+    cfg = Config(tracking_uri="http://x", experiment_name="e", disable_tracing=False)
+    a = MLflowAdapter(cfg)
+    a.register_prompt(
+        name="p",
+        template="t",
+        commit_message="c",
+        tags={"k": "v"},
+        model_config={"temperature": 0.7, "top_k": 40, "num_ctx": 4096},
+    )
+
+    fake_mlflow.genai.register_prompt.assert_called_once_with(
+        name="p",
+        template="t",
+        commit_message="c",
+        tags={"k": "v"},
+        model_config={"temperature": 0.7, "top_k": 40, "num_ctx": 4096},
     )
 
 

--- a/tests/unit/test_prompt_schema.py
+++ b/tests/unit/test_prompt_schema.py
@@ -21,10 +21,32 @@ def test_good_yaml_parses() -> None:
     assert p.name == "agent_demo"
 
 
-def test_schema_version_must_be_1() -> None:
-    bad = _good() | {"schema_version": 2}
+def test_schema_version_2_accepted_for_model_config() -> None:
+    """Schema bumped to 2 (Issue #2) to allow optional model_config block."""
+    p = PromptYAML(
+        **(_good() | {"schema_version": 2, "model_config": {"temperature": 0.7, "top_k": 40}})
+    )
+    assert p.mlflow_model_config == {"temperature": 0.7, "top_k": 40}
+
+
+def test_schema_version_3_rejected() -> None:
+    bad = _good() | {"schema_version": 3}
     with pytest.raises(Exception):  # noqa: B017
         PromptYAML(**bad)
+
+
+def test_model_config_requires_schema_version_2() -> None:
+    """Setting model_config under schema_version: 1 must fail with a clear error."""
+    bad = _good() | {"model_config": {"temperature": 0.7}}
+    with pytest.raises(Exception, match="schema_version >= 2"):
+        PromptYAML(**bad)
+
+
+def test_v1_without_model_config_still_works() -> None:
+    """Backward-compat: existing v1 prompts (no model_config) keep parsing."""
+    p = PromptYAML(**_good())
+    assert p.schema_version == 1
+    assert p.mlflow_model_config is None
 
 
 def test_name_regex_enforced() -> None:

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -99,12 +99,59 @@ def test_register_prompt_creates_new_when_template_changes(
     from llmops.prompts import register_prompt
 
     genai = fake_mlflow_for_prompts["genai"]
-    genai.load_prompt.return_value = types.SimpleNamespace(name="p", version=1, template="old")
+    genai.load_prompt.return_value = types.SimpleNamespace(
+        name="p", version=1, template="old", model_config=None
+    )
     genai.register_prompt.return_value = types.SimpleNamespace(name="p", version=2)
 
     p = register_prompt(name="p", template="new", commit_message="update")
     assert p.version == 2
     assert genai.register_prompt.called
+
+
+def test_register_prompt_creates_new_when_model_config_changes(
+    fake_mlflow_for_prompts: dict[str, MagicMock],
+) -> None:
+    """Issue #2: idempotence considers model_config — same template but
+    different generation hyperparameters MUST create a new prompt version."""
+    from llmops.prompts import register_prompt
+
+    genai = fake_mlflow_for_prompts["genai"]
+    # Existing version: template "t" with temperature=0.7
+    genai.load_prompt.return_value = types.SimpleNamespace(
+        name="p", version=1, template="t", model_config={"temperature": 0.7}
+    )
+    genai.register_prompt.return_value = types.SimpleNamespace(name="p", version=2)
+
+    p = register_prompt(
+        name="p",
+        template="t",  # same template
+        commit_message="tune",
+        model_config={"temperature": 0.3},  # different hyperparams
+    )
+    assert p.version == 2
+    genai.register_prompt.assert_called_once()
+    assert genai.register_prompt.call_args.kwargs["model_config"] == {"temperature": 0.3}
+
+
+def test_register_prompt_idempotent_when_template_and_model_config_match(
+    fake_mlflow_for_prompts: dict[str, MagicMock],
+) -> None:
+    """Same template AND same model_config → idempotent (no new version)."""
+    from llmops.prompts import register_prompt
+
+    genai = fake_mlflow_for_prompts["genai"]
+    genai.load_prompt.return_value = types.SimpleNamespace(
+        name="p", version=4, template="t", model_config={"temperature": 0.7, "top_k": 40}
+    )
+
+    p = register_prompt(
+        name="p",
+        template="t",
+        model_config={"temperature": 0.7, "top_k": 40},
+    )
+    assert p.version == 4
+    assert genai.register_prompt.call_count == 0
 
 
 def test_prompt_versions_tag_written_on_outer_trace_exit(

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -15,11 +15,12 @@ def fake_mlflow_for_prompts(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicM
     mod.set_tracking_uri = MagicMock()  # type: ignore[attr-defined]
     mod.set_experiment = MagicMock()  # type: ignore[attr-defined]
     mod.set_tag = MagicMock()  # type: ignore[attr-defined]
-    mod.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
+    mod.update_current_trace = MagicMock()  # type: ignore[attr-defined]
     mod.MlflowClient = MagicMock()  # type: ignore[attr-defined]
     genai = types.ModuleType("mlflow.genai")
     genai.register_prompt = MagicMock()  # type: ignore[attr-defined]
     genai.load_prompt = MagicMock()  # type: ignore[attr-defined]
+    genai.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
     mod.genai = genai  # type: ignore[attr-defined]
 
     monkeypatch.setitem(sys.modules, "mlflow", mod)
@@ -217,7 +218,7 @@ def test_set_alias_writes_audit_tags(
     set_alias("agent_tujuan", alias="production", version=3, from_alias="staging")
 
     # The alias pointer was moved on the root mlflow namespace
-    fake_mlflow_for_prompts["mlflow"].set_prompt_alias.assert_called_once_with(
+    fake_mlflow_for_prompts["genai"].set_prompt_alias.assert_called_once_with(
         "agent_tujuan", "production", 3
     )
 

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -10,6 +10,12 @@ def test_public_api_surface() -> None:
     assert callable(llmops.load_prompt)
     assert callable(llmops.register_prompt)
     assert callable(llmops.set_alias)
+    assert callable(llmops.log_hyperparams)
+    assert callable(llmops.set_trace_tags)
+    assert callable(llmops.set_trace_metadata)
+    assert callable(llmops.autolog)
+    assert hasattr(llmops, "SpanType")
+    assert llmops.SpanType.AGENT == "AGENT"
     assert hasattr(llmops, "LLMOpsError")
     assert hasattr(llmops, "LLMOpsConfigError")
     assert hasattr(llmops, "LLMOpsPromptNotFoundError")

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -16,6 +16,8 @@ def test_public_api_surface() -> None:
     assert callable(llmops.autolog)
     assert hasattr(llmops, "SpanType")
     assert llmops.SpanType.AGENT == "AGENT"
+    assert isinstance(llmops.SUPPORTED_PROVIDERS, frozenset)
+    assert "openai" in llmops.SUPPORTED_PROVIDERS
     assert hasattr(llmops, "LLMOpsError")
     assert hasattr(llmops, "LLMOpsConfigError")
     assert hasattr(llmops, "LLMOpsPromptNotFoundError")

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -22,12 +22,12 @@ def fake_mlflow_for_tracing(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicM
     client_mock.start_span = MagicMock(return_value=span_mock)
     client_mock.end_span = MagicMock()
     client_mock.end_trace = MagicMock()
+    client_mock.set_trace_tag = MagicMock()
 
     mod = types.ModuleType("mlflow")
     mod.set_tracking_uri = MagicMock()  # type: ignore[attr-defined]
     mod.set_experiment = MagicMock()  # type: ignore[attr-defined]
     mod.set_tag = MagicMock()  # type: ignore[attr-defined]
-    mod.update_current_trace = MagicMock()  # type: ignore[attr-defined]
     mod.MlflowClient = MagicMock(return_value=client_mock)  # type: ignore[attr-defined]
     genai = types.ModuleType("mlflow.genai")
     genai.register_prompt = MagicMock()  # type: ignore[attr-defined]
@@ -35,14 +35,34 @@ def fake_mlflow_for_tracing(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicM
     genai.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
     mod.genai = genai  # type: ignore[attr-defined]
 
+    # Issue #3 fix: set_trace_metadata uses InMemoryTraceManager (the same path
+    # mlflow.update_current_trace uses internally) because trace_agent builds
+    # traces via the low-level MlflowClient.start_trace API, which does NOT
+    # register a fluent active span — so update_current_trace would no-op.
+    trace_mgr_instance = MagicMock()
+    trace_mgr_instance.set_trace_metadata = MagicMock()
+    trace_mgr_class = MagicMock()
+    trace_mgr_class.get_instance = MagicMock(return_value=trace_mgr_instance)
+    tracing_mod = types.ModuleType("mlflow.tracing")
+    trace_manager_mod = types.ModuleType("mlflow.tracing.trace_manager")
+    trace_manager_mod.InMemoryTraceManager = trace_mgr_class  # type: ignore[attr-defined]
+    tracing_mod.trace_manager = trace_manager_mod  # type: ignore[attr-defined]
+    mod.tracing = tracing_mod  # type: ignore[attr-defined]
+
     monkeypatch.setitem(sys.modules, "mlflow", mod)
     monkeypatch.setitem(sys.modules, "mlflow.genai", genai)
+    monkeypatch.setitem(sys.modules, "mlflow.tracing", tracing_mod)
+    monkeypatch.setitem(sys.modules, "mlflow.tracing.trace_manager", trace_manager_mod)
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://x:5001")
     sys.modules.pop("llmops._mlflow_adapter", None)
     sys.modules.pop("llmops.tracing", None)
     sys.modules.pop("llmops._config", None)
 
-    return {"mlflow": mod, "client": client_mock}
+    return {
+        "mlflow": mod,
+        "client": client_mock,
+        "trace_manager": trace_mgr_instance,
+    }
 
 
 def test_trace_agent_as_context_manager_starts_and_ends_span(
@@ -327,68 +347,99 @@ def test_span_type_constants_are_strings() -> None:
 
 # Tier 1.2: set_trace_tags / set_trace_metadata ----------------------------
 
-def test_set_trace_tags_calls_update_current_trace(
+def test_set_trace_tags_calls_client_set_trace_tag(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
-    """Issue #3: tags must reach TraceInfo.tags via update_current_trace, not
-    span attributes — only the former populates Sessions tab and search filters."""
+    """Issue #3: tags must reach TraceInfo.tags via MlflowClient.set_trace_tag,
+    not span attributes — only the former populates Sessions tab and search
+    filters. Cannot use mlflow.update_current_trace because trace_agent uses
+    client.start_trace which does not register a fluent active span."""
     from llmops.tracing import set_trace_tags, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
 
     with trace_agent("chatbot"):
         set_trace_tags(team="alpha", env="prod")
 
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
-        tags={"team": "alpha", "env": "prod"}
-    )
+    assert client.set_trace_tag.call_count == 2
+    actual_calls = {c.args[1]: c.args[2] for c in client.set_trace_tag.call_args_list}
+    assert actual_calls == {"team": "alpha", "env": "prod"}
+    # All calls used the same trace_id from the active root span (mock returns "r1").
+    trace_ids = {c.args[0] for c in client.set_trace_tag.call_args_list}
+    assert trace_ids == {"r1"}
 
 
 def test_set_trace_tags_coerces_values_to_string(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
-    """MLflow's tags signature is dict[str, str]; non-string values must be
-    coerced at the SDK boundary so consumers can pass ints/floats naturally."""
+    """MLflow's set_trace_tag signature is (trace_id, key, value: str);
+    non-string values must be coerced at the SDK boundary so consumers can
+    pass ints/floats naturally."""
     from llmops.tracing import set_trace_tags, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
 
     with trace_agent("chatbot"):
         set_trace_tags(retry_count=3, latency_ms=124.5, version=2)
 
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
-        tags={"retry_count": "3", "latency_ms": "124.5", "version": "2"}
-    )
+    actual_calls = {c.args[1]: c.args[2] for c in client.set_trace_tag.call_args_list}
+    assert actual_calls == {
+        "retry_count": "3",
+        "latency_ms": "124.5",
+        "version": "2",
+    }
+    for c in client.set_trace_tag.call_args_list:
+        assert isinstance(c.args[2], str)
 
 
 def test_set_trace_tags_outside_trace_does_not_raise(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
-    """Outside an active trace, MLflow logs a warning and the call is a no-op
-    on its side. We still pass through — never raise."""
+    """Outside an active trace, the SDK logs a warning and the call is a
+    no-op — never raises and never reaches MLflow."""
     from llmops.tracing import set_trace_tags
 
     set_trace_tags(team="alpha")  # no exception
+    client = fake_mlflow_for_tracing["client"]
+    client.set_trace_tag.assert_not_called()
 
 
 def test_set_trace_tags_empty_kwargs_skips_call(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
-    from llmops.tracing import set_trace_tags
+    from llmops.tracing import set_trace_tags, trace_agent
 
-    set_trace_tags()
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_not_called()
+    client = fake_mlflow_for_tracing["client"]
+
+    with trace_agent("chatbot"):
+        set_trace_tags()
+
+    client.set_trace_tag.assert_not_called()
 
 
 def test_set_trace_metadata_uses_canonical_keys(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
-    """Issue #3: writes to TraceInfo.request_metadata under
-    mlflow.trace.session / mlflow.trace.user — what the Sessions tab reads."""
+    """Issue #3: writes to TraceInfo.trace_metadata (= request_metadata) under
+    mlflow.trace.session / mlflow.trace.user — what the Sessions tab reads.
+    Goes through InMemoryTraceManager.set_trace_metadata, not the fluent
+    update_current_trace, because trace_agent uses client.start_trace which
+    leaves the fluent active-span tracker empty."""
     from llmops.tracing import set_trace_metadata, trace_agent
+
+    mgr = fake_mlflow_for_tracing["trace_manager"]
 
     with trace_agent("chatbot"):
         set_trace_metadata(session_id="sess-42", user_id="alice")
 
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
-        metadata={"mlflow.trace.session": "sess-42", "mlflow.trace.user": "alice"}
-    )
+    assert mgr.set_trace_metadata.call_count == 2
+    actual = {c.args[1]: c.args[2] for c in mgr.set_trace_metadata.call_args_list}
+    assert actual == {
+        "mlflow.trace.session": "sess-42",
+        "mlflow.trace.user": "alice",
+    }
+    trace_ids = {c.args[0] for c in mgr.set_trace_metadata.call_args_list}
+    assert trace_ids == {"r1"}
 
 
 def test_set_trace_metadata_partial(
@@ -397,12 +448,15 @@ def test_set_trace_metadata_partial(
     """Only set keys for the IDs that were actually provided."""
     from llmops.tracing import set_trace_metadata, trace_agent
 
+    mgr = fake_mlflow_for_tracing["trace_manager"]
+
     with trace_agent("chatbot"):
         set_trace_metadata(session_id="sess-42")
 
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
-        metadata={"mlflow.trace.session": "sess-42"}
-    )
+    assert mgr.set_trace_metadata.call_count == 1
+    call = mgr.set_trace_metadata.call_args_list[0]
+    assert call.args[1] == "mlflow.trace.session"
+    assert call.args[2] == "sess-42"
 
 
 def test_set_trace_metadata_no_args_skips_call(
@@ -410,10 +464,24 @@ def test_set_trace_metadata_no_args_skips_call(
 ) -> None:
     from llmops.tracing import set_trace_metadata, trace_agent
 
+    mgr = fake_mlflow_for_tracing["trace_manager"]
+
     with trace_agent("chatbot"):
         set_trace_metadata()
 
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_not_called()
+    mgr.set_trace_metadata.assert_not_called()
+
+
+def test_set_trace_metadata_outside_trace_does_not_raise(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Outside an active trace, the SDK logs a warning and the call is a
+    no-op — never raises and never reaches MLflow."""
+    from llmops.tracing import set_trace_metadata
+
+    set_trace_metadata(session_id="sess-A", user_id="alice")  # no exception
+    mgr = fake_mlflow_for_tracing["trace_manager"]
+    mgr.set_trace_metadata.assert_not_called()
 
 
 def test_set_trace_tags_disabled_is_noop(
@@ -427,7 +495,8 @@ def test_set_trace_tags_disabled_is_noop(
     from llmops.tracing import set_trace_tags
 
     set_trace_tags(team="alpha")
-    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_not_called()
+    client = fake_mlflow_for_tracing["client"]
+    client.set_trace_tag.assert_not_called()
 
 
 # Tier 1.3: set_outputs / decorator auto-capture ---------------------------

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -138,3 +138,366 @@ def test_trace_agent_propagates_user_exception(
     assert client.end_trace.called
     args, kwargs = client.end_trace.call_args
     assert kwargs.get("status") == "ERROR"
+
+
+def test_trace_agent_initialises_adapter_without_prompt_calls(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #1 regression: pure-tracing consumer (no load_prompt) must still
+    trigger MLflowAdapter.initialise() — i.e. mlflow.set_tracking_uri AND
+    mlflow.set_experiment must be called before MlflowClient.start_trace,
+    so traces land in LLMOPS_EXPERIMENT_NAME and not 'Default'."""
+    monkeypatch.setenv("LLMOPS_EXPERIMENT_NAME", "bni-agentic-prd")
+    sys.modules.pop("llmops._config", None)
+    sys.modules.pop("llmops._mlflow_adapter", None)
+    sys.modules.pop("llmops.tracing", None)
+
+    from llmops.tracing import trace_agent
+
+    mlflow_mod = fake_mlflow_for_tracing["mlflow"]
+
+    with trace_agent("chatbot"):
+        pass
+
+    # The adapter ran initialise() exactly once before the trace was started.
+    mlflow_mod.set_tracking_uri.assert_called_once_with("http://x:5001")
+    mlflow_mod.set_experiment.assert_called_once_with("bni-agentic-prd")
+
+    client = fake_mlflow_for_tracing["client"]
+    assert client.start_trace.called
+
+
+def test_log_hyperparams_sets_span_attributes(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Issue #2 Option 2: log_hyperparams writes llmops.hp.* attributes onto
+    the currently-active span via Span.set_attributes."""
+    from llmops.tracing import log_hyperparams, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    # The fake start_trace returns a SimpleNamespace; replace its set_attributes
+    # with a MagicMock so we can assert the call.
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    with trace_agent("chatbot"):
+        log_hyperparams(model="qwen2.5:7b", temperature=0.7, top_k=40, num_ctx=4096)
+
+    root_span.set_attributes.assert_called_once()
+    (attrs,) = root_span.set_attributes.call_args.args
+    assert attrs == {
+        "llmops.hp.model": "qwen2.5:7b",
+        "llmops.hp.temperature": 0.7,
+        "llmops.hp.top_k": 40,
+        "llmops.hp.num_ctx": 4096,
+    }
+
+
+def test_log_hyperparams_attaches_to_innermost_span(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """When called inside a nested trace_agent, attributes attach to the
+    inner span, not the outer trace root."""
+    from llmops.tracing import log_hyperparams, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s_root"
+    client.start_trace.return_value = root_span
+
+    inner_span = MagicMock()
+    inner_span.trace_id = "r1"
+    inner_span.span_id = "s_inner"
+    client.start_span.return_value = inner_span
+
+    with trace_agent("orchestrator"):  # noqa: SIM117
+        with trace_agent("inner"):
+            log_hyperparams(temperature=0.3)
+
+    inner_span.set_attributes.assert_called_once_with({"llmops.hp.temperature": 0.3})
+    root_span.set_attributes.assert_not_called()
+
+
+def test_log_hyperparams_outside_trace_is_noop(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Calling log_hyperparams without an active trace_agent must not raise —
+    it logs a warning and returns."""
+    from llmops.tracing import log_hyperparams
+
+    log_hyperparams(temperature=0.7)  # no exception
+    # The warning is emitted, but we don't pin the exact message text.
+    # Verifying the no-raise behavior is the contract we care about.
+
+
+def test_log_hyperparams_disabled_is_noop(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLMOPS_DISABLE_TRACING", "true")
+    sys.modules.pop("llmops._config", None)
+    sys.modules.pop("llmops.tracing", None)
+
+    from llmops.tracing import log_hyperparams
+
+    log_hyperparams(temperature=0.7)  # no exception, no-op
+    client = fake_mlflow_for_tracing["client"]
+    assert client.start_trace.call_count == 0
+
+
+# Tier 1.1: span_type ------------------------------------------------------
+
+def test_trace_agent_applies_span_type_on_root(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import SpanType, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    with trace_agent("chatbot", span_type=SpanType.AGENT):
+        pass
+
+    root_span.set_span_type.assert_called_once_with("AGENT")
+
+
+def test_trace_agent_applies_span_type_on_nested_span(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import SpanType, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s_root"
+    client.start_trace.return_value = root_span
+
+    inner_span = MagicMock()
+    inner_span.trace_id = "r1"
+    inner_span.span_id = "s_inner"
+    client.start_span.return_value = inner_span
+
+    with trace_agent("orch"):  # noqa: SIM117
+        with trace_agent("retriever_step", span_type=SpanType.RETRIEVER):
+            pass
+
+    inner_span.set_span_type.assert_called_once_with("RETRIEVER")
+    root_span.set_span_type.assert_not_called()
+
+
+def test_trace_agent_no_span_type_skips_call(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """When span_type is omitted (default UNKNOWN), set_span_type is not called
+    — MLflow's default UNKNOWN remains in effect without an extra round trip."""
+    from llmops.tracing import trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    with trace_agent("chatbot"):
+        pass
+
+    root_span.set_span_type.assert_not_called()
+
+
+def test_span_type_constants_are_strings() -> None:
+    """SpanType class attrs match MLflow 3.11.x's enum values verbatim."""
+    from llmops.tracing import SpanType
+
+    assert SpanType.LLM == "LLM"
+    assert SpanType.AGENT == "AGENT"
+    assert SpanType.CHAT_MODEL == "CHAT_MODEL"
+    assert SpanType.RETRIEVER == "RETRIEVER"
+    assert SpanType.TOOL == "TOOL"
+    assert SpanType.UNKNOWN == "UNKNOWN"
+
+
+# Tier 1.2: set_trace_tags / set_trace_metadata ----------------------------
+
+def test_set_trace_tags_writes_attributes_on_root_span(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import set_trace_tags, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    inner_span = MagicMock()
+    inner_span.trace_id = "r1"
+    inner_span.span_id = "s2"
+    client.start_span.return_value = inner_span
+
+    with trace_agent("orch"):  # noqa: SIM117
+        with trace_agent("inner"):
+            set_trace_tags(team="alpha", env="prod")
+
+    # Tags always land on root, not the active inner span.
+    root_span.set_attributes.assert_called_once_with({"team": "alpha", "env": "prod"})
+    inner_span.set_attributes.assert_not_called()
+
+
+def test_set_trace_tags_outside_trace_is_noop(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import set_trace_tags
+
+    set_trace_tags(team="alpha")  # no exception
+
+
+def test_set_trace_metadata_uses_canonical_keys(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import set_trace_metadata, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    with trace_agent("chatbot"):
+        set_trace_metadata(session_id="sess-42", user_id="alice")
+
+    root_span.set_attributes.assert_called_once_with(
+        {"mlflow.trace.session": "sess-42", "mlflow.trace.user": "alice"}
+    )
+
+
+def test_set_trace_metadata_partial(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Only set keys for the IDs that were actually provided."""
+    from llmops.tracing import set_trace_metadata, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    with trace_agent("chatbot"):
+        set_trace_metadata(session_id="sess-42")
+
+    root_span.set_attributes.assert_called_once_with({"mlflow.trace.session": "sess-42"})
+
+
+def test_set_trace_metadata_no_args_is_noop(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import set_trace_metadata, trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    root_span = MagicMock()
+    root_span.trace_id = "r1"
+    root_span.span_id = "s1"
+    client.start_trace.return_value = root_span
+
+    with trace_agent("chatbot"):
+        set_trace_metadata()
+
+    root_span.set_attributes.assert_not_called()
+
+
+# Tier 1.3: set_outputs / decorator auto-capture ---------------------------
+
+def test_trace_agent_set_outputs_passed_to_end_trace(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+
+    with trace_agent("chatbot") as t:
+        t.set_outputs({"answer": "halo"})
+
+    end_kwargs = client.end_trace.call_args.kwargs
+    assert end_kwargs["outputs"] == {"answer": "halo"}
+    assert end_kwargs["status"] == "OK"
+
+
+def test_trace_agent_no_set_outputs_omits_outputs_kwarg(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Backward-compat: existing consumers that don't call set_outputs must
+    not have outputs=None forced into end_trace."""
+    from llmops.tracing import trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+
+    with trace_agent("chatbot"):
+        pass
+
+    end_kwargs = client.end_trace.call_args.kwargs
+    assert "outputs" not in end_kwargs
+
+
+def test_trace_agent_decorator_auto_captures_return_value(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import trace_agent
+
+    @trace_agent("agent_tujuan")
+    def f(x: int) -> dict[str, int]:
+        return {"doubled": x * 2}
+
+    assert f(3) == {"doubled": 6}
+
+    client = fake_mlflow_for_tracing["client"]
+    end_kwargs = client.end_trace.call_args.kwargs
+    assert end_kwargs["outputs"] == {"doubled": 6}
+
+
+def test_trace_agent_decorator_does_not_capture_when_function_raises(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """If the wrapped function raises, no outputs are recorded and the trace
+    ends with status=ERROR."""
+    from llmops.tracing import trace_agent
+
+    @trace_agent("agent_tujuan")
+    def f() -> int:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        f()
+
+    client = fake_mlflow_for_tracing["client"]
+    end_kwargs = client.end_trace.call_args.kwargs
+    assert end_kwargs["status"] == "ERROR"
+    assert "outputs" not in end_kwargs
+
+
+def test_trace_agent_set_outputs_on_nested_span_passed_to_end_span(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import trace_agent
+
+    client = fake_mlflow_for_tracing["client"]
+    inner_span = MagicMock()
+    inner_span.trace_id = "r1"
+    inner_span.span_id = "s_inner"
+    client.start_span.return_value = inner_span
+
+    with trace_agent("orch"):  # noqa: SIM117
+        with trace_agent("inner") as inner:
+            inner.set_outputs(42)
+
+    end_span_kwargs = client.end_span.call_args.kwargs
+    assert end_span_kwargs["outputs"] == 42
+
+

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -27,11 +27,12 @@ def fake_mlflow_for_tracing(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicM
     mod.set_tracking_uri = MagicMock()  # type: ignore[attr-defined]
     mod.set_experiment = MagicMock()  # type: ignore[attr-defined]
     mod.set_tag = MagicMock()  # type: ignore[attr-defined]
-    mod.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
+    mod.update_current_trace = MagicMock()  # type: ignore[attr-defined]
     mod.MlflowClient = MagicMock(return_value=client_mock)  # type: ignore[attr-defined]
     genai = types.ModuleType("mlflow.genai")
     genai.register_prompt = MagicMock()  # type: ignore[attr-defined]
     genai.load_prompt = MagicMock()  # type: ignore[attr-defined]
+    genai.set_prompt_alias = MagicMock()  # type: ignore[attr-defined]
     mod.genai = genai  # type: ignore[attr-defined]
 
     monkeypatch.setitem(sys.modules, "mlflow", mod)
@@ -326,55 +327,67 @@ def test_span_type_constants_are_strings() -> None:
 
 # Tier 1.2: set_trace_tags / set_trace_metadata ----------------------------
 
-def test_set_trace_tags_writes_attributes_on_root_span(
+def test_set_trace_tags_calls_update_current_trace(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
+    """Issue #3: tags must reach TraceInfo.tags via update_current_trace, not
+    span attributes — only the former populates Sessions tab and search filters."""
     from llmops.tracing import set_trace_tags, trace_agent
 
-    client = fake_mlflow_for_tracing["client"]
-    root_span = MagicMock()
-    root_span.trace_id = "r1"
-    root_span.span_id = "s1"
-    client.start_trace.return_value = root_span
+    with trace_agent("chatbot"):
+        set_trace_tags(team="alpha", env="prod")
 
-    inner_span = MagicMock()
-    inner_span.trace_id = "r1"
-    inner_span.span_id = "s2"
-    client.start_span.return_value = inner_span
-
-    with trace_agent("orch"):  # noqa: SIM117
-        with trace_agent("inner"):
-            set_trace_tags(team="alpha", env="prod")
-
-    # Tags always land on root, not the active inner span.
-    root_span.set_attributes.assert_called_once_with({"team": "alpha", "env": "prod"})
-    inner_span.set_attributes.assert_not_called()
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
+        tags={"team": "alpha", "env": "prod"}
+    )
 
 
-def test_set_trace_tags_outside_trace_is_noop(
+def test_set_trace_tags_coerces_values_to_string(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
+    """MLflow's tags signature is dict[str, str]; non-string values must be
+    coerced at the SDK boundary so consumers can pass ints/floats naturally."""
+    from llmops.tracing import set_trace_tags, trace_agent
+
+    with trace_agent("chatbot"):
+        set_trace_tags(retry_count=3, latency_ms=124.5, version=2)
+
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
+        tags={"retry_count": "3", "latency_ms": "124.5", "version": "2"}
+    )
+
+
+def test_set_trace_tags_outside_trace_does_not_raise(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Outside an active trace, MLflow logs a warning and the call is a no-op
+    on its side. We still pass through — never raise."""
     from llmops.tracing import set_trace_tags
 
     set_trace_tags(team="alpha")  # no exception
 
 
+def test_set_trace_tags_empty_kwargs_skips_call(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    from llmops.tracing import set_trace_tags
+
+    set_trace_tags()
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_not_called()
+
+
 def test_set_trace_metadata_uses_canonical_keys(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
+    """Issue #3: writes to TraceInfo.request_metadata under
+    mlflow.trace.session / mlflow.trace.user — what the Sessions tab reads."""
     from llmops.tracing import set_trace_metadata, trace_agent
-
-    client = fake_mlflow_for_tracing["client"]
-    root_span = MagicMock()
-    root_span.trace_id = "r1"
-    root_span.span_id = "s1"
-    client.start_trace.return_value = root_span
 
     with trace_agent("chatbot"):
         set_trace_metadata(session_id="sess-42", user_id="alice")
 
-    root_span.set_attributes.assert_called_once_with(
-        {"mlflow.trace.session": "sess-42", "mlflow.trace.user": "alice"}
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
+        metadata={"mlflow.trace.session": "sess-42", "mlflow.trace.user": "alice"}
     )
 
 
@@ -384,33 +397,37 @@ def test_set_trace_metadata_partial(
     """Only set keys for the IDs that were actually provided."""
     from llmops.tracing import set_trace_metadata, trace_agent
 
-    client = fake_mlflow_for_tracing["client"]
-    root_span = MagicMock()
-    root_span.trace_id = "r1"
-    root_span.span_id = "s1"
-    client.start_trace.return_value = root_span
-
     with trace_agent("chatbot"):
         set_trace_metadata(session_id="sess-42")
 
-    root_span.set_attributes.assert_called_once_with({"mlflow.trace.session": "sess-42"})
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_called_once_with(
+        metadata={"mlflow.trace.session": "sess-42"}
+    )
 
 
-def test_set_trace_metadata_no_args_is_noop(
+def test_set_trace_metadata_no_args_skips_call(
     fake_mlflow_for_tracing: dict[str, MagicMock],
 ) -> None:
     from llmops.tracing import set_trace_metadata, trace_agent
 
-    client = fake_mlflow_for_tracing["client"]
-    root_span = MagicMock()
-    root_span.trace_id = "r1"
-    root_span.span_id = "s1"
-    client.start_trace.return_value = root_span
-
     with trace_agent("chatbot"):
         set_trace_metadata()
 
-    root_span.set_attributes.assert_not_called()
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_not_called()
+
+
+def test_set_trace_tags_disabled_is_noop(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLMOPS_DISABLE_TRACING", "true")
+    sys.modules.pop("llmops._config", None)
+    sys.modules.pop("llmops.tracing", None)
+
+    from llmops.tracing import set_trace_tags
+
+    set_trace_tags(team="alpha")
+    fake_mlflow_for_tracing["mlflow"].update_current_trace.assert_not_called()
 
 
 # Tier 1.3: set_outputs / decorator auto-capture ---------------------------


### PR DESCRIPTION
## Summary

Brings `feat/llmops-foundation` into `gos-dev`. Three commits:

- `e6638ae` — `feat(sdk): resolve issues #1, #2 + tier 1 observability primitives`
- `bc8f3ea` — `fix(tracing): resolve issue #3 — trace tags/metadata via update_current_trace` (v1, superseded — fluent vs client thread-local mismatch)
- `daec6ac` — `fix(tracing): issue #3 v2 — use client.set_trace_tag + InMemoryTraceManager.set_trace_metadata` (effective fix)

Closes #1, closes #2, closes #3.

## What works (validated end-to-end against Ollama chatbot)

- **Issue #1** — `trace_agent` calls `MLflowAdapter.initialise()` in `__enter__`. Traces land in `bni-agentic-prd`, 0 leak to `Default`. Consumer no longer needs the `mlflow.set_tracking_uri` / `mlflow.set_experiment` workaround.
- **Issue #2-A** — Prompt YAML `model_config` block round-trips: `llmops.load_prompt("name@staging").model_config` returns the exact dict (`temperature`, `top_k`, `top_p`, `num_ctx`). Versioning + alias rollback works.
- **Issue #2-B** — `llmops.log_hyperparams(**kw)` writes `llmops.hp.*` attributes on the active root span.
- **Issue #3** — `set_trace_metadata` and `set_trace_tags` write to `TraceInfo.request_metadata` / `TraceInfo.tags` via `MlflowClient.set_trace_tag` (tags) and `InMemoryTraceManager.set_trace_metadata` (metadata). `metadata."mlflow.trace.session" = 'X'` filter returns hits, MLflow Sessions tab can group by `mlflow.trace.session` / `mlflow.trace.user`. Zero `mlflow.tracing.fluent` "No active trace" warnings emitted across the whole validation pass.
- **Tier 1 — `span_type`** — `llmops.SpanType` enum re-exported, `trace_agent("...", span_type=SpanType.RETRIEVER)` sets the type on root and nested spans.
- **Tier 1 — `set_outputs`** — Both forms work: `with trace_agent(...) as t: t.set_outputs(value)` and the decorator form auto-captures the wrapped function's return value.
- **Tier 1 — `autolog`** — Provider validation works (`ValueError` on unsupported), dispatch to `mlflow.{provider}.autolog()` confirmed. Not exercised end-to-end (this consumer uses Ollama which is not in `SUPPORTED_PROVIDERS`).
- **DX — minor cleanup**: `FutureWarning` on `set_alias` / `register_prompt` removed (migrated to `mlflow.genai.set_prompt_alias`); `set_trace_tags` docstring uses `tags."env" = 'dev'` filter format; `llmops.SUPPORTED_PROVIDERS` re-exported at top level.

## Test plan

- [x] Issue #1 — trace lands in non-default experiment (no consumer-side workaround)
- [x] Issue #2-A — prompt YAML `model_config` round-trip + alias rollback
- [x] Issue #2-B — `log_hyperparams` writes `llmops.hp.*` attributes
- [x] Issue #3 — `set_trace_metadata` / `set_trace_tags` populate `TraceInfo.request_metadata` / `TraceInfo.tags`; metadata + tags filters return hits; Sessions UI grouping verified via API (3 turns × `session_id="conv-001"` → filter returns 3)
- [x] Tier 1 — `span_type`, `set_outputs` (CM + decorator), `autolog` wiring
- [x] DX nits (FutureWarning, docstring filter syntax, `SUPPORTED_PROVIDERS` re-export)

Validated against MLflow 3.11.1, Python 3.14, Ollama 0.21.2 (`qwen2.5:7b`). See [issue #3 validation comment](https://github.com/gendonholaholo/bni-mlops-mlflow/issues/3#issuecomment-4337210036) for empirical output.

Refs: #1, #2, #3.
