### PR TITLE
fix(tracing): issue #5 — autolog spans nest under trace_agent

### DIFF
--- a/src/llmops/tracing.py
+++ b/src/llmops/tracing.py
@@ -192,6 +192,10 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
         self._trace_handle = None
         self._is_root = False
         self._outputs: Any = _UNSET
+        # Issue #5: token returned by set_span_in_context, used to detach the
+        # span from the fluent OTel context on exit. None when tracing is
+        # disabled or the attach call failed (callers fall back gracefully).
+        self._otel_token: Any = None
 
     def __enter__(self) -> trace_agent:
         cfg = get_config()
@@ -217,6 +221,7 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
                 stack.append(handle)
                 if self.span_type:
                     handle.set_span_type(self.span_type)
+                active_span: Any = handle
             else:
                 parent = stack[-1]
                 span = self._client.start_span(
@@ -230,6 +235,25 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
                 stack.append(span)
                 if self.span_type:
                     span.set_span_type(self.span_type)
+                active_span = span
+
+            # Issue #5: register the span in MLflow's fluent/OTel active-span
+            # context so autolog'd integrations (langchain, openai, etc.) that
+            # resolve their parent via mlflow.get_current_active_span() see this
+            # trace_agent span and nest under it. MlflowClient.start_trace and
+            # start_span themselves use start_span_no_context internally, which
+            # intentionally skips this registration — we mirror the pattern
+            # mlflow's own integrations use (see mlflow/langchain/langchain_tracer.py).
+            try:
+                from mlflow.tracing.provider import set_span_in_context  # noqa: TID253, PLC0415
+
+                self._otel_token = set_span_in_context(active_span)
+            except Exception as e:  # noqa: BLE001
+                _log.warning(
+                    "llmops trace_agent('%s') set_span_in_context failed: %r",
+                    self.name,
+                    e,
+                )
         except Exception as e:  # noqa: BLE001
             _log.warning("llmops trace_agent('%s') start failed: %r", self.name, e)
         return self
@@ -242,6 +266,24 @@ class trace_agent(ContextDecorator):  # noqa: N801 (intentional lowercase API su
             stack = _stack()
             if stack:
                 stack.pop()
+            # Issue #5: detach from fluent OTel context BEFORE ending the trace
+            # so any post-end hooks see the parent context restored. Mirrors the
+            # try/finally pattern in mlflow/langchain/langchain_tracer.py.
+            if self._otel_token is not None:
+                try:
+                    from mlflow.tracing.provider import (  # noqa: TID253, PLC0415
+                        detach_span_from_context,
+                    )
+
+                    detach_span_from_context(self._otel_token)
+                except Exception as e:  # noqa: BLE001
+                    _log.warning(
+                        "llmops trace_agent('%s') detach_span_from_context failed: %r",
+                        self.name,
+                        e,
+                    )
+                finally:
+                    self._otel_token = None
             status = "ERROR" if exc_type else "OK"
             end_kwargs: dict[str, Any] = {"status": status}
             if self._outputs is not _UNSET:

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -49,10 +49,21 @@ def fake_mlflow_for_tracing(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicM
     tracing_mod.trace_manager = trace_manager_mod  # type: ignore[attr-defined]
     mod.tracing = tracing_mod  # type: ignore[attr-defined]
 
+    # Issue #5 fix: trace_agent calls mlflow.tracing.provider.set_span_in_context
+    # to register the span in MLflow's fluent OTel context so autolog'd spans
+    # (langchain, openai, ...) nest under it instead of starting fresh traces.
+    set_span_in_context_mock = MagicMock(return_value="otel-token")
+    detach_span_from_context_mock = MagicMock()
+    provider_mod = types.ModuleType("mlflow.tracing.provider")
+    provider_mod.set_span_in_context = set_span_in_context_mock  # type: ignore[attr-defined]
+    provider_mod.detach_span_from_context = detach_span_from_context_mock  # type: ignore[attr-defined]
+    tracing_mod.provider = provider_mod  # type: ignore[attr-defined]
+
     monkeypatch.setitem(sys.modules, "mlflow", mod)
     monkeypatch.setitem(sys.modules, "mlflow.genai", genai)
     monkeypatch.setitem(sys.modules, "mlflow.tracing", tracing_mod)
     monkeypatch.setitem(sys.modules, "mlflow.tracing.trace_manager", trace_manager_mod)
+    monkeypatch.setitem(sys.modules, "mlflow.tracing.provider", provider_mod)
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://x:5001")
     sys.modules.pop("llmops._mlflow_adapter", None)
     sys.modules.pop("llmops.tracing", None)
@@ -62,6 +73,8 @@ def fake_mlflow_for_tracing(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicM
         "mlflow": mod,
         "client": client_mock,
         "trace_manager": trace_mgr_instance,
+        "set_span_in_context": set_span_in_context_mock,
+        "detach_span_from_context": detach_span_from_context_mock,
     }
 
 
@@ -586,4 +599,94 @@ def test_trace_agent_set_outputs_on_nested_span_passed_to_end_span(
     end_span_kwargs = client.end_span.call_args.kwargs
     assert end_span_kwargs["outputs"] == 42
 
+
+def test_trace_agent_root_attaches_to_fluent_otel_context(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Issue #5: root trace_agent must register in mlflow's fluent OTel context
+    via set_span_in_context so autolog'd integrations (langchain, openai, etc.)
+    that resolve their parent via mlflow.get_current_active_span() see this
+    span and nest under it."""
+    from llmops.tracing import trace_agent
+
+    set_in_ctx = fake_mlflow_for_tracing["set_span_in_context"]
+    detach = fake_mlflow_for_tracing["detach_span_from_context"]
+    client = fake_mlflow_for_tracing["client"]
+
+    with trace_agent("agent_run"):
+        pass
+
+    set_in_ctx.assert_called_once()
+    attached_span = set_in_ctx.call_args.args[0]
+    assert attached_span is client.start_trace.return_value
+    detach.assert_called_once_with("otel-token")
+
+
+def test_trace_agent_nested_attaches_inner_span_to_otel_context(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Issue #5: nested trace_agent must replace the fluent active span with
+    the inner span so autolog calls inside the inner block resolve the inner
+    (not outer) as their parent."""
+    from llmops.tracing import trace_agent
+
+    set_in_ctx = fake_mlflow_for_tracing["set_span_in_context"]
+    detach = fake_mlflow_for_tracing["detach_span_from_context"]
+    client = fake_mlflow_for_tracing["client"]
+    inner_span = MagicMock()
+    inner_span.trace_id = "r1"
+    inner_span.span_id = "s_inner"
+    client.start_span.return_value = inner_span
+
+    with trace_agent("outer"):  # noqa: SIM117
+        with trace_agent("inner"):
+            pass
+
+    assert set_in_ctx.call_count == 2
+    outer_attached = set_in_ctx.call_args_list[0].args[0]
+    inner_attached = set_in_ctx.call_args_list[1].args[0]
+    assert outer_attached is client.start_trace.return_value
+    assert inner_attached is inner_span
+    assert detach.call_count == 2
+
+
+def test_trace_agent_detaches_otel_context_before_end_trace(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Issue #5: detach must happen BEFORE end_trace so any post-end hooks see
+    the parent OTel context restored — mirrors langchain_tracer.py's
+    try/finally pattern."""
+    from llmops.tracing import trace_agent
+
+    detach = fake_mlflow_for_tracing["detach_span_from_context"]
+    client = fake_mlflow_for_tracing["client"]
+    call_order: list[str] = []
+    detach.side_effect = lambda _t: call_order.append("detach")
+    client.end_trace.side_effect = lambda **_kw: call_order.append("end_trace")
+
+    with trace_agent("root"):
+        pass
+
+    assert call_order == ["detach", "end_trace"]
+
+
+def test_trace_agent_set_span_in_context_failure_does_not_crash(
+    fake_mlflow_for_tracing: dict[str, MagicMock],
+) -> None:
+    """Issue #5: if set_span_in_context raises (unexpected mlflow internals
+    change), trace_agent must still log a warning and complete the trace
+    cleanly — autolog nesting is a 'best-effort' enhancement, not a hard
+    requirement for the trace itself to record."""
+    from llmops.tracing import trace_agent
+
+    set_in_ctx = fake_mlflow_for_tracing["set_span_in_context"]
+    detach = fake_mlflow_for_tracing["detach_span_from_context"]
+    client = fake_mlflow_for_tracing["client"]
+    set_in_ctx.side_effect = RuntimeError("otel context attach failed")
+
+    with trace_agent("root"):
+        pass
+
+    detach.assert_not_called()
+    client.end_trace.assert_called_once()
 


### PR DESCRIPTION
## Summary

Fixes #5. `trace_agent` now registers its span in MLflow's fluent OTel active-span context via `mlflow.tracing.provider.set_span_in_context` so autolog'd integrations (langchain, openai, anthropic, …) that resolve their parent via `mlflow.get_current_active_span()` nest under it instead of starting fresh top-level traces.

Mirror of the pattern MLflow's own integrations use (see `mlflow/langchain/langchain_tracer.py:146`): attach token in `__enter__`, detach in `__exit__` BEFORE `end_trace`/`end_span`. Failures in attach/detach are logged + swallowed — autolog nesting is best-effort, must not break the trace.

Benefit beyond langchain: applies to all 17 autolog providers.

## Validation

- 88 unit tests pass (84 prior + 4 new for issue #5: root attach, nested attach inner-span, detach-before-end ordering, attach failure tolerance). Ruff clean.
- E2E with real langchain (`FakeListChatModel`, langchain-core 1.3.2, langchain 1.2.15) on file-store MLflow: single trace recorded, `FakeListChatModel` (CHAT_MODEL) nested under `agent_run` (AGENT).
- Empirical validation by consumer (Mas Gendon, see issue #5 comment): full RAG PRD pipeline (Groq qwen/qwen3-32b + Ollama embedding + pgvector + langchain 1.2.15) — all 7 acceptance items ✅, real trace `generate_prd_validate -> [rag_retrieval, ChatGroq]` recorded as single trace, reasoning content `<think>...</think>` lands in same trace, no new warnings.

## Test plan

- [x] Unit tests pass locally (88/88, ruff clean)
- [x] E2E real-langchain test passes (file-store MLflow + FakeListChatModel)
- [x] Consumer empirical validation passes (RAG PRD pipeline, all 7 acceptance items)
- [x] No regression to Issue #3 fix (`set_trace_tags` + `set_trace_metadata` covered by existing tests)